### PR TITLE
Intercept __cxa_throw_wasm_adapter intead of __cxa_throw_wasm

### DIFF
--- a/system/wasi.cpp
+++ b/system/wasi.cpp
@@ -452,7 +452,7 @@ long WEAK __syscall_exit(int code)
 	return 0;
 }
 
-void __cxa_throw_wasm(void *thrown_object, void *tinfo, void (*dest)(void *))
+void __cxa_throw_wasm_adapter(void *thrown_object, void *tinfo, void (*dest)(void *))
 {
 	const char msg[] = "Exception raised. Aborting...\n";
 	__syscall_write(1, (void*)(msg), sizeof(msg));


### PR DESCRIPTION
ASan needs to insert some code before the abi throwing functions, which it does by overwriting them, executing some asan code, and then calling the actual throwing function again. Cheerp-wasi, however, also overwrites __cxa_throw_wasm which would result in a duplicate symbol error when compiled with ASan. __cxa_throw_wasm just calls __cxa_throw_wasm_adapter, so made it that cheerp-wasi overwrites that function instead so it still works without ASan.

Requires: https://github.com/leaningtech/cheerp-compiler/pull/187