### PR TITLE
wasi/asan: stub out genericjs asan functions

### DIFF
--- a/system/wasi.cpp
+++ b/system/wasi.cpp
@@ -478,3 +478,12 @@ terminate() noexcept
 }
 
 }
+
+namespace __sanitizer {
+using uptr = unsigned int;
+bool IsWasi() { return true; }
+// Stub out genericjs functions
+void InitEnv() {}
+uptr GetCallstack(uptr *dest, uptr dest_len, uptr skip) {}
+uptr GetUtf16FunctionNameAtPc(uptr pc, char16_t *dest, uptr len) {}
+} // namespace __sanitizer


### PR DESCRIPTION
There are a few genericjs functions in libasan that are used to get the callstack or environment variables. When compiling for wasi, however, it will just not emit these functions, resulting in a bunch of undefined imports. This commit stubs out these functions.