### PR TITLE
Fix 4gb __syscall_brk

### DIFF
--- a/system/common.cpp
+++ b/system/common.cpp
@@ -67,19 +67,15 @@ long WEAK __syscall_brk(void* newaddr)
 		brkEnd = ALIGN(_heapStart);
 	}
 	char* a1 = reinterpret_cast<char*>(newaddr);
-	if (a1 < brkEnd)
+	if (a1 <= brkEnd)
 	{
 		return reinterpret_cast<long>(brkEnd);
 	}
-	int length = (char*)newaddr - brkEnd;
-	if (length <= 0)
-	{
-		return reinterpret_cast<long>(brkEnd);
-	}
+	unsigned int length = (char*)newaddr - brkEnd;
 	length = ALIGN(length);
 	if (brkEnd < _heapEnd)
 	{
-		int avail = _heapEnd - brkEnd;
+		unsigned int avail = _heapEnd - brkEnd;
 		if (avail >= length)
 		{
 			brkEnd += length;


### PR DESCRIPTION
Use unsigned integers in __syscall_brk so the comparisons work with values greater than INT_MAX.

Also a minor refactor, the `if (length <= 0)` statement doesn't make much sense any more when `length` is unsigned. We could change this to `if (length == 0)`, but instead I've decided to remove the if statement entirely and change the condition on the if statement before it to `a1 <= brkEnd`. This has the same effect and simplifies the code a little.

Example:

```cpp
#include <cheerp/clientlib.h>
#include <cheerp/client.h>

extern "C" {
        [[cheerp::wasm]]
        long __syscall_brk(void*);
}

[[cheerp::genericjs]]
void install() {
        client::WebAssembly::Memory::prototype->set_("grow", cheerp::Callback([](int pages) {
                client::console.log(pages);
        }));
}

[[cheerp::wasm]]
int main() {
        install();
        __syscall_brk((void*) (4000000000U));
}
```

Before (no output, bad):

```
$ /opt/cheerp/bin/clang++ test.cpp -o test.js -target cheerp-wasm -cheerp-linear-heap-size=4095
$ node test.js
```

After:

```
$ /opt/cheerp/bin/clang++ test.cpp -o test.js -target cheerp-wasm -cheerp-linear-heap-size=4095
$ node test.js
61018
```