### PR TITLE
Move threading syscalls to common

### DIFF
--- a/system/common.cpp
+++ b/system/common.cpp
@@ -381,8 +381,14 @@ long WEAK __syscall_sched_yield()
 	return 0;
 }
 
-long WEAK __syscall_set_thread_area(unsigned long tp)
+#if defined(__CHEERP__) && defined(__ASMJS__)
+[[cheerp::wasm]]
+#endif
+long __syscall_set_thread_area(unsigned long tp)
 {
+	#if defined(__CHEERP__) && defined(__ASMJS__)
+	__builtin_cheerp_set_thread_pointer(tp);
+	#endif
 	return 0;
 }
 
@@ -393,7 +399,7 @@ long WEAK __syscall_clone4(int (*func)(void *), void *stack, int flags, void *ar
 
 long WEAK __syscall_set_tid_address(int *tidptr)
 {
-	return -ENOSYS;
+	return 1;
 }
 
 }

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -103,11 +103,7 @@ long __syscall_futex(int32_t* uaddr, int futex_op, ...)
 }
 
 [[cheerp::wasm]]
-long __syscall_set_thread_area(unsigned long tp)
-{
-	__builtin_cheerp_set_thread_pointer(tp);
-	return 0;
-}
+long __syscall_set_thread_area(unsigned long tp);
 
 [[cheerp::genericjs]]
 void startWorkerFunction(unsigned int fp, unsigned int args, unsigned int tls, int newThreadId, unsigned int stack, unsigned int ctid)


### PR DESCRIPTION
These two syscalls are called from the code that initializes tls, and should always be present.