### PR TITLE
Move set_tid_address to common

### DIFF
--- a/system/common.cpp
+++ b/system/common.cpp
@@ -20,6 +20,9 @@ extern "C" {
 [[cheerp::genericjs]] client::TArray<client::String*>* __builtin_cheerp_environ();
 [[cheerp::genericjs]] client::TArray<client::String*>* __builtin_cheerp_argv();
 
+_Thread_local int tid = 1;
+_Thread_local int *clear_child_tid = nullptr;
+
 extern "C" {
 
 
@@ -394,7 +397,8 @@ long __syscall_set_thread_area(unsigned long tp)
 
 long WEAK __syscall_set_tid_address(int *tidptr)
 {
-	return 1;
+	clear_child_tid = tidptr;
+	return tid;
 }
 
 }

--- a/system/impl.h
+++ b/system/impl.h
@@ -11,6 +11,9 @@ namespace sys_internal {
 	bool exit_thread();
 }
 
+extern _Thread_local int tid;
+extern _Thread_local int *clear_child_tid;
+
 extern "C" {
 void __syscall_main_args(int* argc, char*** argv);
 }

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -27,9 +27,6 @@ namespace [[cheerp::genericjs]] client {
 [[cheerp::genericjs]] client::ThreadingObject* __builtin_cheerp_get_threading_object();
 [[cheerp::genericjs]] client::Blob* __builtin_cheerp_get_threading_blob();
 
-_Thread_local int tid = 1;
-_Thread_local int *clear_child_tid = nullptr;
-
 extern "C" {
 
 long __syscall_futex(int32_t* uaddr, int futex_op, ...)
@@ -185,12 +182,6 @@ long WEAK __syscall_clone4(int (*func)(void *), void *stack, int flags, void *ar
 
 	startWorkerFunction((unsigned int)func, (unsigned int)arg, (unsigned int)tlsPointer, newThreadId, (unsigned int)stack, (unsigned int)set_tid);
 	return newThreadId;
-}
-
-long __syscall_set_tid_address(int *tidptr)
-{
-	clear_child_tid = tidptr;
-	return tid;
 }
 
 }


### PR DESCRIPTION
The syscall set_tid_address is now fully moved to the common library, so there's only one version of this function now.