### PR TITLE
Thread kill rework

### DIFF
--- a/system/browser.cpp
+++ b/system/browser.cpp
@@ -198,10 +198,17 @@ bool WEAK exit_thread()
 
 extern "C" {
 
+[[cheerp::genericjs]]
+void WEAK worker_close()
+{
+	return;
+}
+
 long WEAK __syscall_exit(long code)
 {
 	if (sys_internal::exit_thread())
 	{
+		worker_close();
 		return 0;
 	}
 

--- a/system/browser.cpp
+++ b/system/browser.cpp
@@ -13,8 +13,6 @@ extern "C" {
 #include "impl.h"
 #include "futex.h"
 
-_Thread_local atomicWaitStatus canUseAtomicWait = UNINITIALIZED;
-
 namespace {
 
 class [[cheerp::genericjs]] CheerpStringBuilder

--- a/system/impl.h
+++ b/system/impl.h
@@ -14,15 +14,8 @@ namespace sys_internal {
 	bool exit_thread();
 }
 
-enum atomicWaitStatus {
-	UNINITIALIZED = 0,
-	YES,
-	NO,
-};
-
 extern _Thread_local int tid;
 extern _Thread_local int *clear_child_tid;
-extern _Thread_local atomicWaitStatus canUseAtomicWait;
 
 class FutexSpinLock
 {

--- a/system/impl.h
+++ b/system/impl.h
@@ -50,6 +50,20 @@ struct ThreadSpawnInfo {
 	int ctid;
 };
 
+enum QueueMessageType {
+	SPAWN_THREAD = 0,
+	KILL_THREAD,
+	KILL_ALL_THREADS,
+};
+
+struct QueueMessage {
+	QueueMessageType type;
+	union {
+		ThreadSpawnInfo spawnInfo;
+		int tid;
+	};
+};
+
 template <typename T>
 class MessageQueue
 {

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -298,6 +298,12 @@ void spawnUtility()
 	utilityWorker->addEventListener("message", callStart);
 }
 
+[[cheerp::genericjs]]
+void worker_close()
+{
+	client::self.close();
+}
+
 long WEAK __syscall_gettid(void)
 {
 	return tid;

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -349,7 +349,7 @@ void spawnUtility()
 	utilityWorker->addEventListener("message", callStart);
 }
 
-[[cheerp::genericjs]]
+[[cheerp::genericjs]] [[noreturn]]
 void worker_close()
 {
 	QueueMessage message;
@@ -358,6 +358,8 @@ void worker_close()
 	message.tid = threadingObject->get_tid();
 	threadMessagingQueue.send(message);
 	client::self.close();
+	client::String* throwObj = new client::String("ThreadExit");
+	__builtin_cheerp_throw(throwObj);
 }
 
 long WEAK __syscall_gettid(void)
@@ -490,10 +492,12 @@ long __syscall_exit_group(long code)
 
 namespace sys_internal {
 
-[[cheerp::genericjs]]
+[[cheerp::genericjs]] [[noreturn]]
 void closeMainThreadAsWorker()
 {
 	client::self.close();
+	client::String* throwObj = new client::String("ExitMainThreadWorker");
+	__builtin_cheerp_throw(throwObj);
 }
 
 bool exit_thread()

--- a/system/wasi.cpp
+++ b/system/wasi.cpp
@@ -19,8 +19,6 @@ extern "C" {
 
 #include "impl.h"
 
-_Thread_local atomicWaitStatus canUseAtomicWait = UNINITIALIZED;
-
 namespace sys_internal {
 
 double timezone_offset()


### PR DESCRIPTION
This PR adds bookkeeping to the utility thread about the threads it spawns, so it can kill them when the main program exits.