### PR TITLE
Change exit code catching and reporting

### DIFF
--- a/system/browser.cpp
+++ b/system/browser.cpp
@@ -168,7 +168,9 @@ double performanceNow()
 
 [[cheerp::genericjs]] [[noreturn]] void raiseSignal(int code)
 {
-	client::CheerpException* wrapper = new client::CheerpException("Cheerp: Signal raised", true, code);
+	client::String* exitMessageText = new client::String("Program exited with code ");
+	client::String* exitMessage = exitMessageText->concat(new client::String(code));
+	client::CheerpException* wrapper = new client::CheerpException(exitMessage, true, code);
 	__builtin_cheerp_throw(wrapper);
 	__builtin_unreachable();
 }

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -346,7 +346,7 @@ void callStart()
 	// We wrap the entrypoint into a try/catch for the exit exception.
 	// This code is a duplication of compileEntryPoint in the CheerpWriter.
 	client::EventListener* jsStart = cheerp::Callback(startWrapper);
-	__asm__("try{%0()}catch(e){if(e instanceof CheerpException&&e.isExit){if(e.code!=0)console.log('Program failed. Exit code:', e.code);}else{throw(e);}}" :: "r"(jsStart));
+	__asm__("try{%0()}catch(e){if(!(e instanceof CheerpException&&e.isExit&&e.code==0))throw(e);}" :: "r"(jsStart));
 	__builtin_cheerp_thread_setup_resolve();
 }
 


### PR DESCRIPTION
The exit code is now put inside the exit exception, and the exit exception is no longer printed in the console. Unless the exit code is 0, the exception will be left uncaught.