### PR TITLE
Modified exit_thread behaviour for node

### DIFF
--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -509,9 +509,17 @@ void closeMainThreadAsWorker()
 	__builtin_cheerp_throw(throwObj);
 }
 
+[[cheerp::genericjs]]
+bool doesSelfExist()
+{
+	bool selfExists;
+	__asm__("globalThis.self!==undefined" : "=r"(selfExists));
+	return selfExists;
+}
+
 bool exit_thread()
 {
-	if (!isBrowserMainThread())
+	if (!isBrowserMainThread() && doesSelfExist())
 	{
 		// If the main thread runs in a Worker, close it.
 		if (tid == 1)


### PR DESCRIPTION
There is an additional check specifically for node, that tests whether 'self' is defined before calling self.close(). Node now exits with an ExitException when exit is called.