### PR TITLE
Remove non-WEAK syscall_tkill from threads

### DIFF
--- a/system/common.cpp
+++ b/system/common.cpp
@@ -142,10 +142,9 @@ long WEAK __syscall_clock_gettime64(int clock_id, struct timespec* tp)
 
 long __syscall_exit(long);
 
-long WEAK __syscall_tkill(long a1, ...)
+long WEAK __syscall_tkill(pid_t tid, int sig)
 {
-	__syscall_exit(EX_OSERR);
-	return 0;
+	return sys_internal::tkill(tid, sig);
 }
 
 long WEAK __syscall_exit_group(long code,...)
@@ -413,3 +412,13 @@ long WEAK __syscall_sched_getaffinity(pid_t pid, int cpusetsize, unsigned long* 
 }
 
 }
+
+namespace sys_internal {
+
+long WEAK tkill(pid_t tid, int sig)
+{
+	__syscall_exit(EX_OSERR);
+	return 0;
+}
+
+} // namespace sys_internal

--- a/system/impl.h
+++ b/system/impl.h
@@ -12,6 +12,7 @@ namespace sys_internal {
 	double monotonic_time_now();
 	double cpu_time_now();
 	bool exit_thread();
+	long tkill(pid_t tid, int sig);
 }
 
 extern _Thread_local int tid;

--- a/system/threads.cpp
+++ b/system/threads.cpp
@@ -500,21 +500,6 @@ long __syscall_exit_group(long code)
 	return 0;
 }
 
-long __syscall_tkill(pid_t tid, int sig)
-{
-	// If we receive a SIGCANCEL here, we kill the thread specified. In musl, SIGCANCEL is 33.
-	if (sig == 33)
-	{
-		QueueMessage message;
-		message.type = QueueMessageType::KILL_THREAD;
-		message.tid = tid;
-		threadMessagingQueue.send(message);
-	}
-	else
-		__syscall_exit(EX_OSERR);
-	return 0;
-}
-
 }
 
 namespace sys_internal {
@@ -555,4 +540,19 @@ bool exit_thread()
 	return false;
 }
 
+long tkill(pid_t tid, int sig)
+{
+	// If we receive a SIGCANCEL here, we kill the thread specified. In musl, SIGCANCEL is 33.
+	if (sig == 33)
+	{
+		QueueMessage message;
+		message.type = QueueMessageType::KILL_THREAD;
+		message.tid = tid;
+		threadMessagingQueue.send(message);
+	}
+	else
+		__syscall_exit(EX_OSERR);
+	return 0;
 }
+
+} // namespace sys_internal


### PR DESCRIPTION
Instead, the implementation now uses an internal function that is overwritten by threads.