### PR TITLE
Futex - don't check atomics for WASI

### DIFF
--- a/system/common.cpp
+++ b/system/common.cpp
@@ -156,7 +156,7 @@ long WEAK __syscall_futex(uint32_t* uaddr, int futex_op, ...)
 {
 	va_list args;
 	va_start(args, futex_op);
-	int ret = sys_internal::futex(uaddr, futex_op, args);
+	int ret = sys_internal::futex_wrapper(uaddr, futex_op, args);
 	va_end(args);
 	return ret;
 }
@@ -423,7 +423,7 @@ long WEAK sched_getaffinity(pid_t pid, int cpusetsize, unsigned long* mask)
 	return cpusetsize;
 }
 
-long WEAK futex(uint32_t* uaddr, int futex_op, va_list args)
+long WEAK futex(uint32_t* uaddr, int futex_op, bool canUseAtomics, va_list args)
 {
 	return -ENOSYS;
 }

--- a/system/impl.h
+++ b/system/impl.h
@@ -15,8 +15,10 @@ namespace sys_internal {
 	long tkill(pid_t tid, int sig);
 	long exit_group(long code);
 	long sched_getaffinity(pid_t pid, int cpusetsize, unsigned long* mask);
-	long futex(uint32_t* uaddr, int futex_op, va_list args);
+	long futex_wrapper(uint32_t* uaddr, int futex_op, va_list args);
+	long futex(uint32_t* uaddr, int futex_op, bool canUseAtomics, va_list args);
 	[[cheerp::wasm]] void killAllThreads();
+	bool isBrowserMainThread();
 }
 
 extern _Thread_local int tid;

--- a/system/wasi_main.cpp
+++ b/system/wasi_main.cpp
@@ -1,7 +1,9 @@
 // Copyright 2023-2025 Leaning Technologies
 
+#include <cstdarg>
 #include <sysexits.h>
 #include "wasi_api.h"
+#include "impl.h"
 
 extern "C" {
 
@@ -84,4 +86,12 @@ void __syscall_main_environ()
 	environ = cheerp_environ;
 }
 
+} // extern "C"
+
+namespace sys_internal {
+long futex_wrapper(uint32_t* uaddr, int futex_op, va_list args)
+{
+	return futex(uaddr, futex_op, true, args);
 }
+
+} // namespace sys_internal


### PR DESCRIPTION
We don't do the check to see if we can use atomics inside futex anymore. This is passed as an argument from a futex_wrapper instead.