### PR TITLE
Cheerpos fixes6

### DIFF
--- a/system/CMakeLists.txt
+++ b/system/CMakeLists.txt
@@ -21,6 +21,7 @@ if (LIB_TARGET STREQUAL "asmjs")
 	)
 	ADD_LIBRARY(cheerpos STATIC
 		basic.cpp
+		cheerpos.cpp
 		wasi_main.cpp
 		wasi_shim.cpp
 	)

--- a/system/cheerpos.cpp
+++ b/system/cheerpos.cpp
@@ -1,5 +1,6 @@
 // Copyright 2025 Leaning Technologies
 
+#include <stdarg.h>
 #include <string.h>
 
 extern "C" {
@@ -17,6 +18,20 @@ void *dlopen(const char *file, int mode)
 void* __dlsym_time64(void* handle, const char* name)
 {
 	return __dl_symbol(handle, name);
+}
+
+// Forward variadic syscalls to extended versions, we cannot use variadic calls across user/kernel boundary
+// NOTE: This is dirty, there might not be extra arguments, in which case
+//       we read undefined values, but if actually required it should be there
+long __syscall_open_3(const char* pathname, int flags, int mode);
+
+long __syscall_open(const char* pathname, int flags, ...)
+{
+	va_list args;
+	va_start(args, flags);
+	int mode = va_arg(args, int);
+	va_end(args);
+	return __syscall_open_3(pathname, flags, mode);
 }
 
 }

--- a/system/cheerpos.cpp
+++ b/system/cheerpos.cpp
@@ -1,5 +1,6 @@
 // Copyright 2025 Leaning Technologies
 
+#include <errno.h>
 #include <stdarg.h>
 #include <string.h>
 
@@ -18,6 +19,12 @@ void *dlopen(const char *file, int mode)
 void* __dlsym_time64(void* handle, const char* name)
 {
 	return __dl_symbol(handle, name);
+}
+
+long __syscall_statx(long a1,...)
+{
+	// Make this fail to reach the 64-bit versions
+	return -ENOSYS;
 }
 
 // Forward variadic syscalls to extended versions, we cannot use variadic calls across user/kernel boundary

--- a/system/cheerpos.cpp
+++ b/system/cheerpos.cpp
@@ -1,0 +1,22 @@
+// Copyright 2025 Leaning Technologies
+
+#include <string.h>
+
+extern "C" {
+
+extern void* __dl_open(const char* file, int mode);
+extern void* __dl_symbol(void* handle, const char* name);
+
+// Implement dlopen / dlsym at the kernel level
+void *dlopen(const char *file, int mode)
+{
+	// Override dlopen with an implementation that won't link cleanly
+	return __dl_open(file, strlen(file));
+}
+
+void* __dlsym_time64(void* handle, const char* name)
+{
+	return __dl_symbol(handle, name);
+}
+
+}

--- a/system/cheerpos.cpp
+++ b/system/cheerpos.cpp
@@ -41,4 +41,15 @@ long __syscall_open(const char* pathname, int flags, ...)
 	return __syscall_open_3(pathname, flags, mode);
 }
 
+long __syscall_fcntl64_3(int fd, int op, int arg);
+
+long __syscall_fcntl64(int fd, int op, ...)
+{
+	va_list args;
+	va_start(args, op);
+	int arg = va_arg(args, int);
+	va_end(args);
+	return __syscall_fcntl64_3(fd, op, arg);
+}
+
 }


### PR DESCRIPTION
The CheerpOS kernel implements directly most syscalls, but for a few we need adaptation. The `cheerpos.cpp` file provides this layer if needed.